### PR TITLE
[Fix] Fix the bug of the declaration of `BufferLoad`

### DIFF
--- a/tests/cpp/src/relax/expr-test.py
+++ b/tests/cpp/src/relax/expr-test.py
@@ -1,3 +1,4 @@
+import tvm
 import tvm.relax as rx
 from tvm import tir
 from tvm.script import ir as I, relax as R, tir as T
@@ -49,7 +50,8 @@ false_blocks = [rx.BindingBlock(false_bindings)]
 false_seq_expr = rx.SeqExpr(false_blocks, false_blocks[-1].bindings[-1].var)
 
 # build If node
-if_node = rx.If(cond=cond, true_branch=true_seq_expr, false_branch=false_seq_expr)
+if_node = rx.If(cond=cond, true_branch=true_seq_expr,
+                false_branch=false_seq_expr)
 
 if_node.show()
 
@@ -68,10 +70,12 @@ y = rx.Var("y", scalar_struct_info)
 
 
 inner_block = rx.BindingBlock(
-    [rx.VarBinding(x0, rx.const(2, "int32")), rx.VarBinding(y, rx.Call(f, [x0]))]
+    [rx.VarBinding(x0, rx.const(2, "int32")),
+     rx.VarBinding(y, rx.Call(f, [x0]))]
 )
 
-inner_func = rx.Function([ipt], rx.SeqExpr([inner_block], y), scalar_struct_info)
+inner_func = rx.Function([ipt], rx.SeqExpr(
+    [inner_block], y), scalar_struct_info)
 
 outer_block = rx.BindingBlock(
     [

--- a/tests/cpp/src/tir/expr-test.cc
+++ b/tests/cpp/src/tir/expr-test.cc
@@ -222,7 +222,7 @@ void TirBufferLoadTest() {
   LOG_PRINT_VAR(bufferflatten->data_alignment);
   LOG_PRINT_VAR(bufferflatten->offset_factor);
   LOG_PRINT_VAR(bufferflatten->buffer_type);
-  
+
   /// Define a BufferLoad instance.
   // clang-format off
   /// Lanes of `predicate` of `Bufferload` must be consistent with the `dtype.lanes` of
@@ -230,7 +230,7 @@ void TirBufferLoadTest() {
   /// The indices can set its last index to be a vector type (with DataType's lanes > 1).
   /// @todo (yangjianchao) Supplement more details about indices with its last index being
   /// with DataType's lanes > 1.
-  BufferLoad bufferload{buffer, {2, 4}, Broadcast{tvm::Bool{true}, 4}};
+  BufferLoad bufferload{buffer, {2, 4,8}, Broadcast{tvm::Bool{true}, 4}};
   // clang-format on
   LOG_PRINT_VAR(bufferload);
   LOG_PRINT_VAR(bufferload->buffer->data);


### PR DESCRIPTION
expr-test.cc: change the dimension of `indices` to be 3D, matching the shape of `buffer`.Otherwise, Abort(core dumped)
expr-test.py: File format the script.