### PR TITLE
Find a way to call `LoopPartition` and other `Passes` in C++ by modifying the source code of TVM

### DIFF
--- a/gitfetch.sh
+++ b/gitfetch.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Script: gitfetch.sh
+# Purpose: Automatically retry `git fetch` with arguments until success
+#          or max retries reached.
+# Handles timeouts (e.g., due to the FUCKING network provider) and other failures(e.g., the FUCKING DNS spoofing).
+# Usage: ./gitfetch.sh [any git fetch arguments, e.g. upstream main]
+# Note: It's user's pesponsibility for safe command.
+#       Only works well on Linux systems. We have not test it on MacOS.
+
+# Maximum number of retries
+MAX_RETRIES=100
+retry_count=0
+
+# Timeout for git fetch (in seconds)
+FETCH_TIMEOUT=20
+
+# Loop until git fetch succeeds or the maximum number of retries is reached
+while [ $retry_count -lt $MAX_RETRIES ]; do
+    echo "Attempting git fetch ${@}... (Attempt: $((retry_count + 1))/$MAX_RETRIES)"
+
+    # Execute git fetch with arguments and a timeout
+    timeout $FETCH_TIMEOUT git fetch "$@"
+
+    # Check the exit status of git fetch
+    fetch_exit_code=$?
+    if [ $fetch_exit_code -eq 0 ]; then
+        echo "Git fetch succeeded!"
+        exit 0  # Exit the script if successful
+    elif [ $fetch_exit_code -eq 124 ]; then
+        # Git fetch timed out (likely waiting for user input)
+        echo "Git fetch timed out (possibly waiting for user input). Retrying..."
+    else
+        # Git fetch failed for other reasons
+        echo "Git fetch failed with exit code $fetch_exit_code. Retrying..."
+    fi
+
+    retry_count=$((retry_count + 1))
+    sleep 1  # Wait 1 seconds before retrying
+done
+
+# If the maximum number of retries is reached without success
+echo "Maximum retries reached ($MAX_RETRIES attempts), git fetch still failed."
+exit 1  # Exit the script with an error code

--- a/tests/cpp/include/tir/transform-test.h
+++ b/tests/cpp/include/tir/transform-test.h
@@ -1,16 +1,25 @@
 #include "tvm/tir/transform.h"
+#include <../src/tir/transforms/loop_partition.h>
 #include <tvm/ir/expr.h>
 #include <tvm/ir/module.h>
 #include <tvm/ir/type.h>
 #include <tvm/node/functor.h>
+#include <tvm/runtime/container/base.h>
 #include <tvm/tir/buffer.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
 #include <tvm/tir/stmt.h>
+#include <tvm/tir/var.h>
 
 namespace transform_test {
 
 using tvm::Bool;
+using tvm::make_object;
 using tvm::ObjectRef;
+using tvm::With;
 using tvm::runtime::String;
+using tvm::tir::LoopPartitionConfig;
+using tvm::tir::LoopPartitionConfigNode;
 using tvm::transform::Pass;
 using tvm::transform::PassContext;
 using tvm::transform::PassContextNode;
@@ -96,7 +105,10 @@ using tvm::tir::transform::VectorizeLoop;
 using tvm::DataType;
 using tvm::IntImm;
 using tvm::IRModule;
+using tvm::likely;
+using tvm::PointerType;
 using tvm::PrimExpr;
+using tvm::PrimType;
 using tvm::Range;
 using tvm::VoidType;
 using tvm::runtime::Array;
@@ -106,6 +118,7 @@ using tvm::tir::Buffer;
 using tvm::tir::BufferLoad;
 using tvm::tir::BufferRegion;
 using tvm::tir::BufferStore;
+using tvm::tir::BufferType;
 using tvm::tir::decl_buffer;
 using tvm::tir::Evaluate;
 using tvm::tir::For;
@@ -114,7 +127,9 @@ using tvm::tir::IfThenElse;
 using tvm::tir::IterVar;
 using tvm::tir::IterVarType;
 using tvm::tir::PrimFunc;
+using tvm::tir::Select;
 using tvm::tir::SeqStmt;
+using tvm::tir::SizeVar;
 using tvm::tir::Stmt;
 using tvm::tir::Var;
 

--- a/tests/cpp/include/tir/transform-test.h
+++ b/tests/cpp/include/tir/transform-test.h
@@ -2,11 +2,15 @@
 #include <tvm/ir/expr.h>
 #include <tvm/ir/module.h>
 #include <tvm/ir/type.h>
+#include <tvm/node/functor.h>
 #include <tvm/tir/buffer.h>
 #include <tvm/tir/stmt.h>
 
 namespace transform_test {
 
+using tvm::Bool;
+using tvm::ObjectRef;
+using tvm::runtime::String;
 using tvm::transform::Pass;
 using tvm::transform::PassContext;
 using tvm::transform::PassContextNode;
@@ -99,7 +103,9 @@ using tvm::runtime::Array;
 using tvm::runtime::Map;
 using tvm::tir::Block;
 using tvm::tir::Buffer;
+using tvm::tir::BufferLoad;
 using tvm::tir::BufferRegion;
+using tvm::tir::BufferStore;
 using tvm::tir::decl_buffer;
 using tvm::tir::Evaluate;
 using tvm::tir::For;
@@ -114,5 +120,6 @@ using tvm::tir::Var;
 
 IRModule SimpleFor();
 void TirVectorizeLoopTest();
+void TirPartitionLoopTest();
 
 }  // namespace transform_test

--- a/tests/cpp/main.cc
+++ b/tests/cpp/main.cc
@@ -223,6 +223,7 @@ void TestMethod2(bool listAllNames, bool onlyListAllNames) {
   // registry->RunTestSuite("tir_data_layout_test_TirBijectiveLayoutTest");
   // registry->RunTestSuite("tir_transform_test_TirVectorizeLoopTest");
   registry->RunTestSuite("tir_transform_test_TirPartitionLoopTest");
+  registry->RunTestSuite("tir_transform_test_TirUnrollLoopTest");
   // registry->RunTestSuite("tir_stmt_functor_test_TirStmtFunctorTest");
   // registry->RunTestSuite("tir_stmt_functor_test_TirOtherVisitorMutatorTest");
   // registry->RunTestSuite("tir_index_map_test_TirIndexMapTest");

--- a/tests/cpp/main.cc
+++ b/tests/cpp/main.cc
@@ -222,6 +222,7 @@ void TestMethod2(bool listAllNames, bool onlyListAllNames) {
   // registry->RunTestSuite("tir_data_layout_test_TirLayoutTest");
   // registry->RunTestSuite("tir_data_layout_test_TirBijectiveLayoutTest");
   // registry->RunTestSuite("tir_transform_test_TirVectorizeLoopTest");
+  registry->RunTestSuite("tir_transform_test_TirPartitionLoopTest");
   // registry->RunTestSuite("tir_stmt_functor_test_TirStmtFunctorTest");
   // registry->RunTestSuite("tir_stmt_functor_test_TirOtherVisitorMutatorTest");
   // registry->RunTestSuite("tir_index_map_test_TirIndexMapTest");

--- a/tests/cpp/src/tir/builtin-test.cc
+++ b/tests/cpp/src/tir/builtin-test.cc
@@ -20,7 +20,12 @@ void TirretTest() {
   LOG_PRINT_VAR(call);
 }
 
-void TirreinterpretTest() {}
+void TirreinterpretTest() {
+  LOG_SPLIT_LINE("TirreinterpretTest");
+  auto &op = reinterpret();
+  LOG_PRINT_VAR(op->name);
+  tvm::tir::Call call{tvm::DataType::Float(32), op, {tvm::PrimExpr{1}}};
+}
 
 void TirlikelyTest() {}
 

--- a/tests/cpp/src/tir/transform-test.cc
+++ b/tests/cpp/src/tir/transform-test.cc
@@ -6,8 +6,10 @@
 #include <tvm/ir/module.h>
 #include <tvm/ir/transform.h>
 #include <tvm/runtime/container/map.h>
+#include <tvm/runtime/data_type.h>
 #include <tvm/support/with.h>
 #include <tvm/tir/function.h>
+#include <tvm/tir/op.h>
 #include <tvm/tir/stmt.h>
 #include <tvm/tir/var.h>
 
@@ -115,52 +117,116 @@ void TirVectorizeLoopTest() {
 IRModule PartitionedLoop() {
 
   /// @brief the sample below refers to
-  Var i("i", DataType::Int(32));
-  Var j("j", DataType::Int(32));
-  Buffer buffA = decl_buffer({40}, DataType::Int(32), "A");
-  Buffer buffB = decl_buffer({40}, DataType::Int(32), "B");
+  Var i("i"), j("j"), k("k");
 
-  Stmt loop_j =
-      For(j, 0, 10, ForKind::kSerial,
-          IfThenElse((i * 10 + j < 36),
-                     BufferStore(buffA, BufferLoad(buffB, {10 * i + j}), {10 * i + j})));
+  Var m("m"), n("n");
 
+  Stmt loop_k = For(k, 0, m, ForKind::kSerial,
+                    IfThenElse(likely(i * m + j + k < n), Evaluate(m), Evaluate(n)));
+  Stmt loop_j = For(j, 0, n, ForKind::kSerial, loop_k);
   Stmt loop_i = For(i, 0, 4, ForKind::kSerial, loop_j);
 
-  Map<Var, Buffer> buffer_map;
-  buffer_map.Set(buffA->data, buffA);
-  buffer_map.Set(buffB->data, buffB);
-
-  PrimFunc func(/*params=*/{}, loop_i, VoidType(), buffer_map);
+  PrimFunc func(/*params=*/{m, n}, loop_i, VoidType());
   return IRModule::FromExpr(func);
 }
 
+/// @brief reproduce the bug in tvm/src/tir/transforms/loop_partition.cc
+/// @todo can be removed as the bug has been fixed now.
+void reproduce() {
+
+  Var m("m"), n("n");
+  Var i("i");
+
+  Select sel(likely(i == 5), m, n);
+  Evaluate eval(sel);
+
+  Stmt loop = For(i, 0, 10, ForKind::kSerial, eval);
+
+  PrimFunc mainFunc({m, n}, loop, VoidType(), {});
+  IRModule mod = IRModule::FromExpr(mainFunc);
+
+  LOG_PRINT_VAR(mod);
+
+  /// (partition_const_loop: true)
+  auto configNode = make_object<LoopPartitionConfigNode>();
+
+  configNode->partition_const_loop = true;
+  configNode->no_unroll_loop_with_extent_one = true;
+  configNode->unroll_loop_with_partition_hint_no_interval = true;
+
+  LoopPartitionConfig config(configNode);
+
+  PassContext pass_ctx = PassContext::Create();
+  Map<String, ObjectRef> pass_config;
+
+  pass_config.Set("tir.LoopPartition", config);
+  pass_ctx->config = pass_config;
+
+  /// @bug @BenkangPeng Aborted(core dumped)
+  /// dump at tir/ir/transform.cc line121: func = pass_func(std::move(func), mod,
+  /// pass_ctx);
+  {
+    With<PassContext> scope(pass_ctx);
+    IRModule partitionedMod = LoopPartition()(mod);
+    LOG_PRINT_VAR(partitionedMod);
+  }
+}
 void TirPartitionLoopTest() {
+
+  reproduce();
 
   LOG_SPLIT_LINE("TirPartitionLoopTest");
   auto mod = PartitionedLoop();
   LOG_PRINT_VAR(mod);  /// output:
-  // mod: # from tvm.script import ir as I
-  // # from tvm.script import tir as T
-  // @I.ir_module
-  // class Module:
-  //     @T.prim_func(private=True)
-  //     def main():
-  //         A = T.Buffer((40,), "int32")
-  //         B = T.Buffer((40,), "int32")
-  //         for i, j in T.grid(4, 10):
-  //             if i * 10 + j < 36:
-  //                 A[10 * i + j] = B[10 * i + j]
 
-  /// (partition_const_loop: true)
+  auto configNode = make_object<LoopPartitionConfigNode>();
+  configNode->partition_const_loop = true;
+  configNode->no_unroll_loop_with_extent_one = false;
+  configNode->unroll_loop_with_partition_hint_no_interval = false;
+
+  LoopPartitionConfig config(configNode);
+  PassContext pass_ctx = PassContext::Create();
+  Map<String, ObjectRef> pass_config;
+
+  pass_config.Set("tir.LoopPartition", config);
+  pass_ctx->config = pass_config;
+  {
+    tvm::With<PassContext> scope(pass_ctx);
+
+    auto pass = LoopPartition();
+
+    auto partitionedMod = pass(mod);
+    LOG_PRINT_VAR(partitionedMod);
+  }
+}
+
+void TirUnrollLoopTest() {
+  SizeVar n("n");
+  Var i("i"), j("j");
+
+  DataType dtype = DataType::Int(32, 1);
+  Var bufPtr("bufferPtr", PointerType(PrimType(dtype), "global"));
+
+  Buffer buf = Buffer(bufPtr, dtype, {n}, {1}, 0, "buffer", 4, 0, BufferType::kDefault);
+  Stmt body = BufferStore(buf, BufferLoad(buf, {i}) + 1, {j + 1});
+
+  Stmt loop_j = For(j, 0, 8, ForKind::kUnrolled, body);
+  Stmt loop_i = For(i, n, (n + 2 - n), ForKind::kSerial, loop_j);
+
+  Map<Var, Buffer> map;
+  map.Set(bufPtr, buf);
+  PrimFunc func({bufPtr}, loop_i, VoidType(), map);
+
+  IRModule mod = IRModule::FromExpr(func);
+
+  LOG_PRINT_VAR(mod);
+
   Map<tvm::String, ObjectRef> inner_config;
-  inner_config.Set("partition_const_loop", Bool(true));
-  inner_config.Set("no_unroll_loop_with_extent_one", Bool(false));
-  inner_config.Set("unroll_loop_with_partition_hint_no_interval", Bool(false));
+  inner_config.Set("auto_max_step", PrimExpr(16));
 
   /// (tir.LoopPartition: inner_config)
   Map<String, ObjectRef> pass_config;
-  pass_config.Set("tir.LoopPartition", inner_config);
+  pass_config.Set("tir.UnrollLoop", inner_config);
 
   PassContext pass_ctx = PassContext::Current();
   pass_ctx->config = pass_config;
@@ -168,15 +234,7 @@ void TirPartitionLoopTest() {
   {
     tvm::With<PassContext> scope(pass_ctx);
 
-    PassContext current = PassContext::Current();
-    LOG(INFO) << "Current PassContext: " << current;
-
-    if (!current.defined()) {
-      LOG(FATAL) << "PassContext is NULL!";
-    }
-
-    auto pass = LoopPartition();
-    LOG(INFO) << "Creating LoopPartition pass";
+    auto pass = UnrollLoop();
 
     /// @bug @BenkangPeng Aborted(core dumped)
     /// dump at tir/ir/transform.cc line121: func = pass_func(std::move(func), mod,
@@ -195,3 +253,5 @@ REGISTER_TEST_SUITE(transform_test::TirVectorizeLoopTest,
                     tir_transform_test_TirVectorizeLoopTest);
 REGISTER_TEST_SUITE(transform_test::TirPartitionLoopTest,
                     tir_transform_test_TirPartitionLoopTest);
+REGISTER_TEST_SUITE(transform_test::TirUnrollLoopTest,
+                    tir_transform_test_TirUnrollLoopTest);

--- a/tests/cpp/src/tir/transform-test.cc
+++ b/tests/cpp/src/tir/transform-test.cc
@@ -11,6 +11,7 @@
 #include <tvm/tir/function.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt.h>
+#include <tvm/tir/transform.h>
 #include <tvm/tir/var.h>
 
 namespace transform_test {
@@ -116,7 +117,6 @@ void TirVectorizeLoopTest() {
 
 IRModule PartitionedLoop() {
 
-  /// @brief the sample below refers to
   Var i("i"), j("j"), k("k");
 
   Var m("m"), n("n");
@@ -239,10 +239,7 @@ void TirUnrollLoopTest() {
     /// @bug @BenkangPeng Aborted(core dumped)
     /// dump at tir/ir/transform.cc line121: func = pass_func(std::move(func), mod,
     /// pass_ctx);
-    // auto partitionedMod = pass(mod);
-
-    // LOG(INFO) << "Pass applied successfully";
-
+    // auto partitionedMod = UnrollLoop()(mod);
     // LOG_PRINT_VAR(partitionedMod);  // the same as mod, no change
   }
 }

--- a/tests/cpp/src/tir/transform-test.cc
+++ b/tests/cpp/src/tir/transform-test.cc
@@ -1,9 +1,12 @@
 #include "tir/transform-test.h"
 #include "test-func-registry.h"
+#include <tvm/ir/attrs.h>
 #include <tvm/ir/expr.h>
 #include <tvm/ir/function.h>
 #include <tvm/ir/module.h>
+#include <tvm/ir/transform.h>
 #include <tvm/runtime/container/map.h>
+#include <tvm/support/with.h>
 #include <tvm/tir/function.h>
 #include <tvm/tir/stmt.h>
 #include <tvm/tir/var.h>
@@ -109,7 +112,86 @@ void TirVectorizeLoopTest() {
   /// be included.
 }
 
+IRModule PartitionedLoop() {
+
+  /// @brief the sample below refers to
+  Var i("i", DataType::Int(32));
+  Var j("j", DataType::Int(32));
+  Buffer buffA = decl_buffer({40}, DataType::Int(32), "A");
+  Buffer buffB = decl_buffer({40}, DataType::Int(32), "B");
+
+  Stmt loop_j =
+      For(j, 0, 10, ForKind::kSerial,
+          IfThenElse((i * 10 + j < 36),
+                     BufferStore(buffA, BufferLoad(buffB, {10 * i + j}), {10 * i + j})));
+
+  Stmt loop_i = For(i, 0, 4, ForKind::kSerial, loop_j);
+
+  Map<Var, Buffer> buffer_map;
+  buffer_map.Set(buffA->data, buffA);
+  buffer_map.Set(buffB->data, buffB);
+
+  PrimFunc func(/*params=*/{}, loop_i, VoidType(), buffer_map);
+  return IRModule::FromExpr(func);
+}
+
+void TirPartitionLoopTest() {
+
+  LOG_SPLIT_LINE("TirPartitionLoopTest");
+  auto mod = PartitionedLoop();
+  LOG_PRINT_VAR(mod);  /// output:
+  // mod: # from tvm.script import ir as I
+  // # from tvm.script import tir as T
+  // @I.ir_module
+  // class Module:
+  //     @T.prim_func(private=True)
+  //     def main():
+  //         A = T.Buffer((40,), "int32")
+  //         B = T.Buffer((40,), "int32")
+  //         for i, j in T.grid(4, 10):
+  //             if i * 10 + j < 36:
+  //                 A[10 * i + j] = B[10 * i + j]
+
+  /// (partition_const_loop: true)
+  Map<tvm::String, ObjectRef> inner_config;
+  inner_config.Set("partition_const_loop", Bool(true));
+  inner_config.Set("no_unroll_loop_with_extent_one", Bool(false));
+  inner_config.Set("unroll_loop_with_partition_hint_no_interval", Bool(false));
+
+  /// (tir.LoopPartition: inner_config)
+  Map<String, ObjectRef> pass_config;
+  pass_config.Set("tir.LoopPartition", inner_config);
+
+  PassContext pass_ctx = PassContext::Current();
+  pass_ctx->config = pass_config;
+
+  {
+    tvm::With<PassContext> scope(pass_ctx);
+
+    PassContext current = PassContext::Current();
+    LOG(INFO) << "Current PassContext: " << current;
+
+    if (!current.defined()) {
+      LOG(FATAL) << "PassContext is NULL!";
+    }
+
+    auto pass = LoopPartition();
+    LOG(INFO) << "Creating LoopPartition pass";
+
+    /// @bug @BenkangPeng Aborted(core dumped)
+    /// dump at tir/ir/transform.cc line121: func = pass_func(std::move(func), mod,
+    /// pass_ctx);
+    // auto partitionedMod = pass(mod);
+
+    // LOG(INFO) << "Pass applied successfully";
+
+    // LOG_PRINT_VAR(partitionedMod);  // the same as mod, no change
+  }
+}
+
 }  // namespace transform_test
 
 REGISTER_TEST_SUITE(transform_test::TirVectorizeLoopTest,
                     tir_transform_test_TirVectorizeLoopTest);
+REGISTER_TEST_SUITE(transform_test::TirPartitionLoopTest,
+                    tir_transform_test_TirPartitionLoopTest);

--- a/tests/python/tvm/tir/transform/transform-test.py
+++ b/tests/python/tvm/tir/transform/transform-test.py
@@ -1,0 +1,62 @@
+import tvm
+from tvm.script import ir as I
+from tvm.script import tir as T
+
+testSuites = {}
+
+def register(func):
+    testSuites[func.__name__] = func
+    return func
+
+@register
+def testLoopPartition():
+    
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def main(n: T.int32, m: T.int32):
+            for i, j, k in T.grid(4, n, m):
+                if T.likely(i * m + j + k < n):
+                    T.evaluate(m)
+                else:
+                    T.evaluate(n)   
+    Module.show()
+
+    with tvm.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True}}):
+        Module = tvm.tir.transform.LoopPartition()(Module)
+    
+    print("Partitioned Module:")
+    Module.show()
+
+
+@register
+def testLoopVectorize():
+    pass
+
+
+@register
+def testLoopUnroll():
+
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def main(bufPtr: T.handle):
+            n = T.int32(is_size_var=True)
+            buffer_1 = T.match_buffer(bufPtr, (n,), "int32")
+            for i in range(n, n + (n + 2 - n)):
+                for j in T.unroll(8):
+                    buffer_1[j + 1] = buffer_1[i] + 1
+
+    Module.show()
+    with tvm.transform.PassContext(config={"tir.UnrollLoop": {"auto_max_step": 16}}):
+        ret = tvm.tir.transform.UnrollLoop()(Module)
+
+    ret.show()
+
+if __name__ == "__main__":
+    print("🚀🚀🚀Running test suites:")
+    
+    for __name, __func in testSuites.items():
+        print(f"⏳⏳⏳Running test suite: {__name}")
+        __func()
+        print(f"✅✅✅Test suite: {__name} passed")


### PR DESCRIPTION
In order to call `LoopPartitionConfig` and `LoopPartitionConfigNode`, I have to put the defination of them into the `loop_partition.h`. [🔗refer](https://github.com/BenkangPeng/tvm/commit/2082c3d342e8139bb5979341871a9dbd8f591ec0#diff-9408ae0de1d140b37efd5d9d6e983414782f416f636ec0edbdaa232b361333b8) 
Perhaps it's worth considering whether there are better approaches(don't require modifying the source code of `TVM`).

Then, define the `PassContext` as follow:
```cpp
#include <../src/tir/transforms/loop_partition.h>
auto configNode = make_object<LoopPartitionConfigNode>();
  configNode->partition_const_loop = true;
  configNode->no_unroll_loop_with_extent_one = false;
  configNode->unroll_loop_with_partition_hint_no_interval = false;

  LoopPartitionConfig config(configNode);
  PassContext pass_ctx = PassContext::Create();
  Map<String, ObjectRef> pass_config;

  pass_config.Set("tir.LoopPartition", config);
  pass_ctx->config = pass_config;
  {
    tvm::With<PassContext> scope(pass_ctx);

    auto pass = LoopPartition();

    auto partitionedMod = pass(mod);
    LOG_PRINT_VAR(partitionedMod);
  }
```